### PR TITLE
Python support for asctime and levelname

### DIFF
--- a/klp.py
+++ b/klp.py
@@ -62,14 +62,14 @@ from typing import (
 # Type variable for generic types
 T = TypeVar("T")  # Used for generic type hints if needed
 
-__version__ = "0.74.5"
+__version__ = "0.74.6"
 
 INPUT_QUOTE = r"\""
 
 # Names of keys our program cares about. Use lowercase keys here.
 TS_KEYS = "_klp_timedelta ts time timestamp t at _ts _klp_ts".split()
 MSG_KEYS = "msg message".split()
-LEVEL_KEYS = "log_level level lvl loglevel severity".split()
+LEVEL_KEYS = "log_level level lvl loglevel severity levelname".split()
 
 # Regular expressions
 RE_LOGFMT = re.compile(r'([\w.]+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s]*))')
@@ -3006,7 +3006,7 @@ def get_timestamp_str_or_none(event):
     if args.ts_key:
         return event.get(args.ts_key)
 
-    for key in ("timestamp", "ts", "time", "at", "t"):
+    for key in ("timestamp", "ts", "time", "at", "t", "asctime"):
         value = event.get(key)
         if value is not None:
             return value


### PR DESCRIPTION
see https://github.com/dloss/klp/issues/4

This is working with `python3 klp.py  -S -f jsonl mylogfile.log` as expected.

I am confused why for `levelname`  had to add it to `LEVEL_KEYS`.
But for `asctime` had to add it in line 3009, my expectation was `TS_KEYS`, but that is not working as expected.

Fell free to change code if this is not correct approach or somethings missing. 